### PR TITLE
Upgrade Protostar to 0.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   SCARB_VERSION: v0.2.1
-  PROTOSTAR_VERSION: 0.11.0
+  PROTOSTAR_VERSION: 0.12.0
 
 jobs:
   main:

--- a/cairo_project.toml
+++ b/cairo_project.toml
@@ -1,2 +1,0 @@
-[crate_roots]
-cairo_template = "src"

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,3 +1,2 @@
 [project]
-protostar-version = "0.11.0"
-lib-path = "lib"
+protostar-version = "0.12.0"


### PR DESCRIPTION
Protostar 0.12 will be released tomorrow (30.05.)!
From now on, Protostar will use exclusively Scarb to manage your dependencies. 
Consequences:
- no `cairo_project.toml`
- no `linked-libraries`

Tests should pass when the 0.12 version is released